### PR TITLE
HAP-373 - For multi-module M2 release builds, don't publish artifacts

### DIFF
--- a/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
@@ -316,6 +316,10 @@ public class ArtifactoryRedeployPublisher extends Recorder implements DeployerOv
         return filterExcludedArtifactsFromBuild;
     }
 
+    public boolean isApplicable(AbstractBuild build) {
+        return !isBuildFromM2ReleasePlugin(build);
+    }
+
     @Override
     public Action getProjectAction(AbstractProject<?, ?> project) {
         return details != null ? new ArtifactoryProjectAction(details.getArtifactoryUrl(), project) : null;

--- a/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorHelper.java
+++ b/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorHelper.java
@@ -27,6 +27,9 @@ public abstract class MavenExtractorHelper {
 
         ArtifactoryRedeployPublisher publisher = ActionableHelper.getPublisher(project,
                 ArtifactoryRedeployPublisher.class);
+        if (publisher != null && !publisher.isApplicable(build)) {
+            publisher = null;
+        }
         ArtifactoryMaven3NativeConfigurator resolver = ActionableHelper.getBuildWrapper(
                 project, ArtifactoryMaven3NativeConfigurator.class);
 


### PR DESCRIPTION
When releasing a single Maven module with the M2 Release plugin, the
ArtifactoryRedeployPublisher does not publish any artifacts. This was
implemented under HAP-93.

This change makes multi-module Maven builds act the same way. The
artifactory plugin will act as if there is no ArtifactoryRedeployPublisher
configured when performing a M2 Release, and so will not deploy artifacts.

See also JENKINS-16780, which appears to describe the same bug.
