### PR TITLE
Artifactory Plugin Version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,10 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Artifactory+Plugin</url>
 
     <properties>
-        <buildinfo.version>2.5.1</buildinfo.version>
-        <buildinfo.maven3.version>2.5.0</buildinfo.maven3.version>
-        <buildinfo.gradle.version>3.1.1</buildinfo.gradle.version>
-        <buildinfo.ivy.version>2.5.1</buildinfo.ivy.version>
+        <buildinfo.version>2.5.x-SNAPSHOT</buildinfo.version>
+        <buildinfo.maven3.version>2.5.x-SNAPSHOT</buildinfo.maven3.version>
+        <buildinfo.gradle.version>3.1.x-SNAPSHOT</buildinfo.gradle.version>
+        <buildinfo.ivy.version>2.5.x-SNAPSHOT</buildinfo.ivy.version>
         <maven-release-plugin.version>2.2</maven-release-plugin.version>
     </properties>
 

--- a/src/main/java/org/jfrog/hudson/AbstractBuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/AbstractBuildInfoDeployer.java
@@ -48,7 +48,7 @@ public class AbstractBuildInfoDeployer {
         BuildInfoBuilder builder = new BuildInfoBuilder(
                 BuildUniqueIdentifierHelper.getBuildName(build))
                 .number(BuildUniqueIdentifierHelper.getBuildNumber(build)).type(buildType)
-                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"))
+                .artifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion())
                 .buildAgent(new BuildAgent(buildAgentName, buildAgentVersion))
                 .agent(new Agent("hudson", build.getHudsonVersion()));
         String buildUrl = ActionableHelper.getBuildUrl(build);

--- a/src/main/java/org/jfrog/hudson/AbstractBuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/AbstractBuildInfoDeployer.java
@@ -48,6 +48,7 @@ public class AbstractBuildInfoDeployer {
         BuildInfoBuilder builder = new BuildInfoBuilder(
                 BuildUniqueIdentifierHelper.getBuildName(build))
                 .number(BuildUniqueIdentifierHelper.getBuildNumber(build)).type(buildType)
+                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"))
                 .buildAgent(new BuildAgent(buildAgentName, buildAgentVersion))
                 .agent(new Agent("hudson", build.getHudsonVersion()));
         String buildUrl = ActionableHelper.getBuildUrl(build);

--- a/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
@@ -40,6 +40,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
 import org.jfrog.hudson.BintrayPublish.BintrayPublishAction;
+import org.jfrog.hudson.action.ActionableHelper;
 import org.jfrog.hudson.action.ArtifactoryProjectAction;
 import org.jfrog.hudson.maven2.ArtifactsDeployer;
 import org.jfrog.hudson.maven2.MavenBuildInfoDeployer;
@@ -346,6 +347,13 @@ public class ArtifactoryRedeployPublisher extends Recorder implements DeployerOv
     public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
 
+        //This step runs in maven2 and in maven3 builds, in maven 3 the plugin version printed to the log earlier
+        //so this line should be printed only in case of Maven 2
+        if (isM2Build(build)) {
+            listener.getLogger().println("Jenkins Artifactory Plugin version: " +
+                    ActionableHelper.getArtifactoryPluginVersion());
+        }
+
         if (build.getResult().isWorseThan(getTreshold())) {
             return true;    // build failed. Don't publish
         }
@@ -428,6 +436,12 @@ public class ArtifactoryRedeployPublisher extends Recorder implements DeployerOv
                 return "org.jvnet.hudson.plugins.m2release.ReleaseCause".equals(input.getClass().getName());
             }
         });
+    }
+
+    private boolean isM2Build (AbstractBuild<?, ?> build) {
+        if(build.getClass().getName().contains("MavenModuleSetBuild")
+                && ((MavenModuleSetBuild) build).getMavenVersionUsed().startsWith("2")) return true;
+        return false;
     }
 
     private boolean isExtractorUsed(EnvVars env) {

--- a/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
+++ b/src/main/java/org/jfrog/hudson/ArtifactoryRedeployPublisher.java
@@ -40,7 +40,6 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
 import org.jfrog.hudson.BintrayPublish.BintrayPublishAction;
-import org.jfrog.hudson.action.ActionableHelper;
 import org.jfrog.hudson.action.ArtifactoryProjectAction;
 import org.jfrog.hudson.maven2.ArtifactsDeployer;
 import org.jfrog.hudson.maven2.MavenBuildInfoDeployer;
@@ -347,12 +346,6 @@ public class ArtifactoryRedeployPublisher extends Recorder implements DeployerOv
     public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
 
-        //this step runs in maven2 and in maven3 builds, in maven 3 the plugin version is printing to the log
-        //in much earlier step so this line should be printed only in case od Maven 2
-        if (isM2Build(build)){
-            listener.getLogger().println("Running " + ActionableHelper.getPluginsLongName("artifactory"));
-        }
-
         if (build.getResult().isWorseThan(getTreshold())) {
             return true;    // build failed. Don't publish
         }
@@ -435,12 +428,6 @@ public class ArtifactoryRedeployPublisher extends Recorder implements DeployerOv
                 return "org.jvnet.hudson.plugins.m2release.ReleaseCause".equals(input.getClass().getName());
             }
         });
-    }
-
-    private boolean isM2Build (AbstractBuild<?, ?> build) {
-        if(build.getClass().getName().contains("MavenModuleSetBuild")
-                && ((MavenModuleSetBuild) build).getMavenVersionUsed().startsWith("2")) return true;
-        return false;
     }
 
     private boolean isExtractorUsed(EnvVars env) {

--- a/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
+++ b/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
@@ -17,6 +17,7 @@
 package org.jfrog.hudson.action;
 
 import com.google.common.collect.Lists;
+import hudson.PluginWrapper;
 import hudson.matrix.MatrixConfiguration;
 import hudson.maven.MavenBuild;
 import hudson.maven.reporters.MavenArtifactRecord;
@@ -25,6 +26,7 @@ import hudson.tasks.BuildWrapper;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
 import hudson.util.DescribableList;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.hudson.util.publisher.PublisherFindImpl;
 import org.jfrog.hudson.util.publisher.PublisherFlexible;
@@ -184,5 +186,21 @@ public abstract class ActionableHelper {
             return Collections.emptyList();
 
         return Lists.newArrayList(new ArtifactoryProjectAction(artifactoryRootUrl, project));
+    }
+
+    /**
+     * Returns Plagin's name and version by the provided short name or "Not found"
+     * @param shortName The short name of the plugin
+     * @return Plagin's name and Version if found if not returns "Not found"
+     */
+    public static String getPluginsLongName(String shortName) {
+
+        if(Jenkins.getInstance()!=null
+                && Jenkins.getInstance().getPlugin(shortName)!=null
+                && Jenkins.getInstance().getPlugin(shortName).getWrapper()!=null){
+            PluginWrapper pluginWrapper= Jenkins.getInstance().getPlugin(shortName).getWrapper();
+            return pluginWrapper.getLongName()+": "+pluginWrapper.getVersion();
+        }
+        return "Not found";
     }
 }

--- a/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
+++ b/src/main/java/org/jfrog/hudson/action/ActionableHelper.java
@@ -17,7 +17,6 @@
 package org.jfrog.hudson.action;
 
 import com.google.common.collect.Lists;
-import hudson.PluginWrapper;
 import hudson.matrix.MatrixConfiguration;
 import hudson.maven.MavenBuild;
 import hudson.maven.reporters.MavenArtifactRecord;
@@ -189,18 +188,17 @@ public abstract class ActionableHelper {
     }
 
     /**
-     * Returns Plagin's name and version by the provided short name or "Not found"
-     * @param shortName The short name of the plugin
-     * @return Plagin's name and Version if found if not returns "Not found"
+     * Returns the version of Jenkins Artifactory Plugin or empty string if not found
+     * @return the version of Jenkins Artifactory Plugin or empty string if not found
      */
-    public static String getPluginsLongName(String shortName) {
-
-        if(Jenkins.getInstance()!=null
-                && Jenkins.getInstance().getPlugin(shortName)!=null
-                && Jenkins.getInstance().getPlugin(shortName).getWrapper()!=null){
-            PluginWrapper pluginWrapper= Jenkins.getInstance().getPlugin(shortName).getWrapper();
-            return pluginWrapper.getLongName()+": "+pluginWrapper.getVersion();
+    public static String getArtifactoryPluginVersion(){
+        String pluginsSortName = "artifactory";
+        //Validates Jenkins existence because in some jobs the Jenkins instance is unreachable
+        if(Jenkins.getInstance() != null
+                && Jenkins.getInstance().getPlugin(pluginsSortName) != null
+                && Jenkins.getInstance().getPlugin(pluginsSortName).getWrapper() != null) {
+            return Jenkins.getInstance().getPlugin(pluginsSortName).getWrapper().getVersion();
         }
-        return "Not found";
+        return "";
     }
 }

--- a/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
@@ -16,7 +16,6 @@ import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.api.Artifact;
 import org.jfrog.build.api.Dependency;
 import org.jfrog.build.api.dependency.BuildDependency;
-import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.ProxyConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryDependenciesClient;
@@ -258,8 +257,7 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
     @Override
     public Environment setUp(final AbstractBuild build, Launcher launcher, BuildListener listener)
             throws IOException, InterruptedException {
-        Log log = new JenkinsBuildInfoLog(listener);
-        log.info("Running "+ ActionableHelper.getPluginsLongName("artifactory"));
+        listener.getLogger().println("Jenkins Artifactory Plugin version: " + ActionableHelper.getArtifactoryPluginVersion());
         RepositoriesUtils.validateServerConfig(build, listener, getArtifactoryServer(), getArtifactoryUrl());
 
         final String artifactoryServerName = getArtifactoryName();

--- a/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.api.Artifact;
 import org.jfrog.build.api.Dependency;
 import org.jfrog.build.api.dependency.BuildDependency;
+import org.jfrog.build.api.util.Log;
 import org.jfrog.build.client.ProxyConfiguration;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryBuildInfoClient;
 import org.jfrog.build.extractor.clientConfiguration.client.ArtifactoryDependenciesClient;
@@ -257,6 +258,8 @@ public class ArtifactoryGenericConfigurator extends BuildWrapper implements Depl
     @Override
     public Environment setUp(final AbstractBuild build, Launcher launcher, BuildListener listener)
             throws IOException, InterruptedException {
+        Log log = new JenkinsBuildInfoLog(listener);
+        log.info("Running "+ ActionableHelper.getPluginsLongName("artifactory"));
         RepositoriesUtils.validateServerConfig(build, listener, getArtifactoryServer(), getArtifactoryUrl());
 
         final String artifactoryServerName = getArtifactoryName();

--- a/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
@@ -412,7 +412,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
     public Environment setUp(final AbstractBuild build, Launcher launcher, final BuildListener listener)
             throws IOException, InterruptedException {
         final PrintStream log = listener.getLogger();
-        log.println("Running " + ActionableHelper.getPluginsLongName("artifactory"));
+        log.println( "Jenkins Artifactory Plugin version: " + ActionableHelper.getArtifactoryPluginVersion());
         PublisherContext.Builder publisherBuilder = getBuilder();
         RepositoriesUtils.validateServerConfig(build, listener, getArtifactoryServer(), getArtifactoryUrl());
 
@@ -634,7 +634,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
                         isBlackDuckIncludePublishedArtifacts(), isAutoCreateMissingComponentRequests(),
                         isAutoDiscardStaleComponentRequests())
                 .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild())
-                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
+                .artifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion());
     }
 
     public boolean isRelease(AbstractBuild build) {

--- a/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator.java
@@ -56,6 +56,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.util.*;
 
@@ -410,6 +411,8 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
     @Override
     public Environment setUp(final AbstractBuild build, Launcher launcher, final BuildListener listener)
             throws IOException, InterruptedException {
+        final PrintStream log = listener.getLogger();
+        log.println("Running " + ActionableHelper.getPluginsLongName("artifactory"));
         PublisherContext.Builder publisherBuilder = getBuilder();
         RepositoriesUtils.validateServerConfig(build, listener, getArtifactoryServer(), getArtifactoryUrl());
 
@@ -421,7 +424,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
             if (isDeployArtifacts()) {
                 if (StringUtils.isBlank(getArtifactoryCombinationFilter())) {
                     String error = "The field \"Combination Matches\" is empty, but is defined as mandatory!";
-                    listener.getLogger().println(error);
+                    log.println(error);
                     build.setResult(Result.FAILURE);
                     throw new IllegalArgumentException(error);
                 }
@@ -475,7 +478,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
                 }
             };
         } else {
-            listener.getLogger().println("[Warning] No Gradle build configured");
+            log.println("[Warning] No Gradle build configured");
         }
 
         final PublisherContext.Builder finalPublisherBuilder = publisherBuilder;
@@ -496,7 +499,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
                     env.put("ARTIFACTORY_INIT_SCRIPT", " --init-script " + initScriptPath);
 
                 } catch (Exception e) {
-                    listener.getLogger().println("Error occurred while writing Gradle Init Script: " + e.getMessage());
+                    log.println("Error occurred while writing Gradle Init Script: " + e.getMessage());
                     build.setResult(Result.FAILURE);
                 }
 
@@ -526,7 +529,7 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
                     ExtractorUtils.addBuilderInfoArguments(env, build, listener, finalPublisherBuilder.build(),
                             resolverContext);
                 } catch (Exception e) {
-                    listener.getLogger().println(e.getMessage());
+                    log.println(e.getMessage());
                     throw new RuntimeException(e);
                 }
             }
@@ -630,7 +633,8 @@ public class ArtifactoryGradleConfigurator extends BuildWrapper implements Deplo
                         getBlackDuckReportRecipients(), getBlackDuckScopes(),
                         isBlackDuckIncludePublishedArtifacts(), isAutoCreateMissingComponentRequests(),
                         isAutoDiscardStaleComponentRequests())
-                .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild());
+                .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild())
+                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
     }
 
     public boolean isRelease(AbstractBuild build) {

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator.java
@@ -355,8 +355,8 @@ public class ArtifactoryIvyConfigurator extends AntIvyBuildWrapper implements De
     @Override
     public Environment setUp(final AbstractBuild build, Launcher launcher, final BuildListener listener)
             throws IOException, InterruptedException {
-        String artifactoryPluginVersion = ActionableHelper.getPluginsLongName("artifactory");
-        listener.getLogger().println("Running "+ artifactoryPluginVersion);
+        String artifactoryPluginVersion = ActionableHelper.getArtifactoryPluginVersion();
+        listener.getLogger().println( "Jenkins Artifactory Plugin version: " + artifactoryPluginVersion);
         File localDependencyFile = Which.jarFile(ArtifactoryBuildListener.class);
         final FilePath actualDependencyDir =
                 PluginDependencyHelper.getActualDependencyDirectory(build, localDependencyFile);

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator.java
@@ -355,6 +355,8 @@ public class ArtifactoryIvyConfigurator extends AntIvyBuildWrapper implements De
     @Override
     public Environment setUp(final AbstractBuild build, Launcher launcher, final BuildListener listener)
             throws IOException, InterruptedException {
+        String artifactoryPluginVersion = ActionableHelper.getPluginsLongName("artifactory");
+        listener.getLogger().println("Running "+ artifactoryPluginVersion);
         File localDependencyFile = Which.jarFile(ArtifactoryBuildListener.class);
         final FilePath actualDependencyDir =
                 PluginDependencyHelper.getActualDependencyDirectory(build, localDependencyFile);
@@ -373,6 +375,7 @@ public class ArtifactoryIvyConfigurator extends AntIvyBuildWrapper implements De
                         getBlackDuckReportRecipients(), getBlackDuckScopes(), isBlackDuckIncludePublishedArtifacts(),
                         isAutoCreateMissingComponentRequests(), isAutoDiscardStaleComponentRequests())
                 .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild())
+                .artifactoryPluginVersion(artifactoryPluginVersion)
                 .build();
         build.setResult(Result.SUCCESS);
         return new AntIvyBuilderEnvironment() {

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
@@ -335,6 +335,7 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
     @Override
     public Environment setUp(final AbstractBuild build, Launcher launcher, final BuildListener listener)
             throws IOException, InterruptedException {
+        listener.getLogger().println("Running "+ ActionableHelper.getPluginsLongName("artifactory"));
         PublisherContext.Builder publisherBuilder = getBuilder();
         RepositoriesUtils.validateServerConfig(build, listener, getArtifactoryServer(), getArtifactoryUrl());
         final String buildName = BuildUniqueIdentifierHelper.getBuildName(build);
@@ -484,7 +485,8 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
                 .integrateBlackDuck(isBlackDuckRunChecks(), getBlackDuckAppName(), getBlackDuckAppVersion(),
                         getBlackDuckReportRecipients(), getBlackDuckScopes(), isBlackDuckIncludePublishedArtifacts(),
                         isAutoCreateMissingComponentRequests(), isAutoDiscardStaleComponentRequests())
-                .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild());
+                .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild())
+                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
     }
 
     public ArtifactoryServer getArtifactoryServer() {

--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
@@ -335,7 +335,8 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
     @Override
     public Environment setUp(final AbstractBuild build, Launcher launcher, final BuildListener listener)
             throws IOException, InterruptedException {
-        listener.getLogger().println("Running "+ ActionableHelper.getPluginsLongName("artifactory"));
+        listener.getLogger().println(
+                "Jenkins Artifactory Plugin version: " + ActionableHelper.getArtifactoryPluginVersion());
         PublisherContext.Builder publisherBuilder = getBuilder();
         RepositoriesUtils.validateServerConfig(build, listener, getArtifactoryServer(), getArtifactoryUrl());
         final String buildName = BuildUniqueIdentifierHelper.getBuildName(build);
@@ -486,7 +487,7 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
                         getBlackDuckReportRecipients(), getBlackDuckScopes(), isBlackDuckIncludePublishedArtifacts(),
                         isAutoCreateMissingComponentRequests(), isAutoDiscardStaleComponentRequests())
                 .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild())
-                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
+                .artifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion());
     }
 
     public ArtifactoryServer getArtifactoryServer() {

--- a/src/main/java/org/jfrog/hudson/maven2/MavenDependenciesRecorder.java
+++ b/src/main/java/org/jfrog/hudson/maven2/MavenDependenciesRecorder.java
@@ -17,18 +17,15 @@
 package org.jfrog.hudson.maven2;
 
 import hudson.Extension;
-import hudson.maven.MavenBuild;
-import hudson.maven.MavenBuildProxy;
+import hudson.Launcher;
+import hudson.maven.*;
 import hudson.maven.MavenBuildProxy.BuildCallable;
-import hudson.maven.MavenModule;
-import hudson.maven.MavenReporter;
-import hudson.maven.MavenReporterDescriptor;
-import hudson.maven.MojoInfo;
 import hudson.model.BuildListener;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.jfrog.hudson.MavenDependenciesRecord;
 import org.jfrog.hudson.MavenDependency;
+import org.jfrog.hudson.action.ActionableHelper;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -107,6 +104,13 @@ public class MavenDependenciesRecorder extends MavenReporter {
         public MavenReporter newAutoInstance(MavenModule module) {
             return new MavenDependenciesRecorder();
         }
+    }
+
+    //The method end is the first method where Jenkins instance is reachable which needed for the Plugin Version Printing
+    @Override
+    public boolean end(MavenBuild build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        listener.getLogger().println("Jenkins Artifactory Plugin version: " + ActionableHelper.getArtifactoryPluginVersion());
+        return true;
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jfrog/hudson/maven2/MavenDependenciesRecorder.java
+++ b/src/main/java/org/jfrog/hudson/maven2/MavenDependenciesRecorder.java
@@ -17,15 +17,18 @@
 package org.jfrog.hudson.maven2;
 
 import hudson.Extension;
-import hudson.Launcher;
-import hudson.maven.*;
+import hudson.maven.MavenBuild;
+import hudson.maven.MavenBuildProxy;
 import hudson.maven.MavenBuildProxy.BuildCallable;
+import hudson.maven.MavenModule;
+import hudson.maven.MavenReporter;
+import hudson.maven.MavenReporterDescriptor;
+import hudson.maven.MojoInfo;
 import hudson.model.BuildListener;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.jfrog.hudson.MavenDependenciesRecord;
 import org.jfrog.hudson.MavenDependency;
-import org.jfrog.hudson.action.ActionableHelper;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -104,13 +107,6 @@ public class MavenDependenciesRecorder extends MavenReporter {
         public MavenReporter newAutoInstance(MavenModule module) {
             return new MavenDependenciesRecorder();
         }
-    }
-
-    //The method end is the first method where Jenkins instance is reachable which needed for the Plugin Version Printing
-    @Override
-    public boolean end(MavenBuild build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        listener.getLogger().println("Jenkins Artifactory Plugin version: " + ActionableHelper.getArtifactoryPluginVersion());
-        return true;
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
+++ b/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
@@ -425,7 +425,7 @@ public class ArtifactoryMaven3Configurator extends BuildWrapper implements Deplo
                         getBlackDuckReportRecipients(), getBlackDuckScopes(), isBlackDuckIncludePublishedArtifacts(),
                         isAutoCreateMissingComponentRequests(), isAutoDiscardStaleComponentRequests())
                 .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild())
-                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
+                .artifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion());
 
         if (isMultiConfProject(build) && isDeployArtifacts()) {
             if (StringUtils.isBlank(getArtifactoryCombinationFilter())) {

--- a/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
+++ b/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator.java
@@ -424,7 +424,8 @@ public class ArtifactoryMaven3Configurator extends BuildWrapper implements Deplo
                 .integrateBlackDuck(isBlackDuckRunChecks(), getBlackDuckAppName(), getBlackDuckAppVersion(),
                         getBlackDuckReportRecipients(), getBlackDuckScopes(), isBlackDuckIncludePublishedArtifacts(),
                         isAutoCreateMissingComponentRequests(), isAutoDiscardStaleComponentRequests())
-                .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild());
+                .filterExcludedArtifactsFromBuild(isFilterExcludedArtifactsFromBuild())
+                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
 
         if (isMultiConfProject(build) && isDeployArtifacts()) {
             if (StringUtils.isBlank(getArtifactoryCombinationFilter())) {

--- a/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator.java
@@ -16,12 +16,14 @@ import org.jfrog.hudson.ArtifactoryServer;
 import org.jfrog.hudson.ResolverOverrider;
 import org.jfrog.hudson.ServerDetails;
 import org.jfrog.hudson.VirtualRepository;
+import org.jfrog.hudson.action.ActionableHelper;
 import org.jfrog.hudson.util.*;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -81,11 +83,13 @@ public class ArtifactoryMaven3NativeConfigurator extends BuildWrapper implements
             };
         }
 
+        PrintStream log = listener.getLogger();
+        log.println("Running "+ActionableHelper.getPluginsLongName("artifactory"));
         EnvVars envVars = build.getEnvironment(listener);
         boolean supportedMavenVersion =
                 MavenVersionHelper.isAtLeastResolutionCapableVersion((MavenModuleSetBuild) build, envVars, listener);
         if (!supportedMavenVersion) {
-            listener.getLogger().println("Artifactory resolution is not active. Maven 3.0.2 or higher is required to " +
+            log.println("Artifactory resolution is not active. Maven 3.0.2 or higher is required to " +
                     "force resolution from Artifactory.");
             return new Environment() {
             };

--- a/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator.java
@@ -84,7 +84,7 @@ public class ArtifactoryMaven3NativeConfigurator extends BuildWrapper implements
         }
 
         PrintStream log = listener.getLogger();
-        log.println("Running "+ActionableHelper.getPluginsLongName("artifactory"));
+        log.println("Jenkins Artifactory Plugin version: " + ActionableHelper.getArtifactoryPluginVersion());
         EnvVars envVars = build.getEnvironment(listener);
         boolean supportedMavenVersion =
                 MavenVersionHelper.isAtLeastResolutionCapableVersion((MavenModuleSetBuild) build, envVars, listener);

--- a/src/main/java/org/jfrog/hudson/maven3/Maven3Builder.java
+++ b/src/main/java/org/jfrog/hudson/maven3/Maven3Builder.java
@@ -28,6 +28,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.build.api.BuildInfoConfigProperties;
 import org.jfrog.build.extractor.maven.Maven3BuildInfoLogger;
+import org.jfrog.hudson.action.ActionableHelper;
 import org.jfrog.hudson.util.PluginDependencyHelper;
 import org.jfrog.hudson.util.plugins.PluginsUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -78,6 +79,7 @@ public class Maven3Builder extends Builder {
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
+        listener.getLogger().println("Running "+ ActionableHelper.getPluginsLongName("artifactory"));
         EnvVars env = build.getEnvironment(listener);
         FilePath workDir = build.getModuleRoot();
         ArgumentListBuilder cmdLine = buildMavenCmdLine(build, listener, env, launcher);

--- a/src/main/java/org/jfrog/hudson/maven3/Maven3Builder.java
+++ b/src/main/java/org/jfrog/hudson/maven3/Maven3Builder.java
@@ -79,7 +79,7 @@ public class Maven3Builder extends Builder {
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
-        listener.getLogger().println("Running "+ ActionableHelper.getPluginsLongName("artifactory"));
+        listener.getLogger().println("Jenkins Artifactory Plugin version: " + ActionableHelper.getArtifactoryPluginVersion());
         EnvVars env = build.getEnvironment(listener);
         FilePath workDir = build.getModuleRoot();
         ArgumentListBuilder cmdLine = buildMavenCmdLine(build, listener, env, launcher);

--- a/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
+++ b/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
@@ -206,7 +206,7 @@ public class MavenExtractorEnvironment extends Environment {
                         publisher.isAutoCreateMissingComponentRequests(),
                         publisher.isAutoDiscardStaleComponentRequests())
                 .filterExcludedArtifactsFromBuild(publisher.isFilterExcludedArtifactsFromBuild())
-                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"))
+                .artifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion())
                 .build();
 
         return context;

--- a/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
+++ b/src/main/java/org/jfrog/hudson/maven3/extractor/MavenExtractorEnvironment.java
@@ -206,6 +206,7 @@ public class MavenExtractorEnvironment extends Environment {
                         publisher.isAutoCreateMissingComponentRequests(),
                         publisher.isAutoDiscardStaleComponentRequests())
                 .filterExcludedArtifactsFromBuild(publisher.isFilterExcludedArtifactsFromBuild())
+                .artifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"))
                 .build();
 
         return context;

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -154,6 +154,8 @@ public class ExtractorUtils {
                     publisherContext.getAggregationBuildStatus()).setIssueTrackerInfo(configuration);
         }
 
+        publisherContext.setArtifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
+
         IncludesExcludes envVarsPatterns = new IncludesExcludes("", "");
         if (publisherContext != null && publisherContext.getEnvVarsPatterns() != null) {
             envVarsPatterns = publisherContext.getEnvVarsPatterns();
@@ -223,6 +225,7 @@ public class ExtractorUtils {
         String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
         configuration.info.setBuildNumber(buildNumber);
         configuration.publisher.addMatrixParam("build.number", buildNumber);
+        configuration.info.setArtifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
 
         Date buildStartDate = build.getTimestamp().getTime();
         configuration.info.setBuildStarted(buildStartDate.getTime());

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -34,7 +34,6 @@ import org.jfrog.build.extractor.clientConfiguration.ArtifactoryClientConfigurat
 import org.jfrog.build.extractor.clientConfiguration.ClientProperties;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.hudson.ArtifactoryServer;
-import org.jfrog.hudson.DeployerOverrider;
 import org.jfrog.hudson.ServerDetails;
 import org.jfrog.hudson.action.ActionableHelper;
 import org.jfrog.hudson.release.ReleaseAction;
@@ -154,7 +153,7 @@ public class ExtractorUtils {
                     publisherContext.getAggregationBuildStatus()).setIssueTrackerInfo(configuration);
         }
 
-        publisherContext.setArtifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
+        publisherContext.setArtifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion());
 
         IncludesExcludes envVarsPatterns = new IncludesExcludes("", "");
         if (publisherContext != null && publisherContext.getEnvVarsPatterns() != null) {
@@ -225,7 +224,7 @@ public class ExtractorUtils {
         String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
         configuration.info.setBuildNumber(buildNumber);
         configuration.publisher.addMatrixParam("build.number", buildNumber);
-        configuration.info.setArtifactoryPluginVersion(ActionableHelper.getPluginsLongName("artifactory"));
+        configuration.info.setArtifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion());
 
         Date buildStartDate = build.getTimestamp().getTime();
         configuration.info.setBuildStarted(buildStartDate.getTime());

--- a/src/main/java/org/jfrog/hudson/util/publisher/PublisherContext.java
+++ b/src/main/java/org/jfrog/hudson/util/publisher/PublisherContext.java
@@ -64,6 +64,7 @@ public class PublisherContext {
     private boolean autoDiscardStaleComponentRequests;
     private boolean filterExcludedArtifactsFromBuild;
     private boolean recordAllDependencies;
+    private String artifactoryPluginVersion;
 
     private PublisherContext() {
     }
@@ -214,6 +215,14 @@ public class PublisherContext {
 
     public boolean isFilterExcludedArtifactsFromBuild() {
         return filterExcludedArtifactsFromBuild;
+    }
+
+    public String getArtifactoryPluginVersion() {
+        return artifactoryPluginVersion;
+    }
+
+    public void setArtifactoryPluginVersion(String artifactoryPluginVersion) {
+        this.artifactoryPluginVersion = artifactoryPluginVersion;
     }
 
     public static class Builder {
@@ -376,6 +385,11 @@ public class PublisherContext {
 
         public Builder filterExcludedArtifactsFromBuild(boolean filterExcludedArtifactsFromBuild) {
             publisher.filterExcludedArtifactsFromBuild = filterExcludedArtifactsFromBuild;
+            return this;
+        }
+
+        public Builder artifactoryPluginVersion(String artifactoryPluginVersion){
+            publisher.artifactoryPluginVersion = artifactoryPluginVersion;
             return this;
         }
     }


### PR DESCRIPTION
Adding a print of the Artifactory plugin version to the logs in all of the supported by the plugin jobs and to the Build-Info JSON.
This should help in troubleshooting.
In Artifactory the artifactoryPluginVersion field will be available in Build-Info JSON only after updating Artifactory with a supported buildInfo version.