### PR TITLE
Fix NPE when building a job concurrently. (Option: "Execute concurrent builds if necessary")

### DIFF
--- a/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
+++ b/src/main/java/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator.java
@@ -338,7 +338,7 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
                 "Jenkins Artifactory Plugin version: " + ActionableHelper.getArtifactoryPluginVersion());
         PublisherContext.Builder publisherBuilder = getBuilder();
         RepositoriesUtils.validateServerConfig(build, listener, getArtifactoryServer(), getArtifactoryUrl());
-        final String buildName = BuildUniqueIdentifierHelper.getBuildName(build);
+
         int totalBuilds = 1;
 
         if (isMultiConfProject(build)) {
@@ -359,13 +359,13 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
             // inside its setUp() method is invoked by only one job in this build
             // (matrix project builds include more that one job) and that all other jobs
             // wait till the seUup() method finishes.
-            new ConcurrentJobsHelper.ConcurrentBuildSetupSync(buildName, totalBuilds) {
+            new ConcurrentJobsHelper.ConcurrentBuildSetupSync(build, totalBuilds) {
                 @Override
                 public void setUp() {
                     // Obtain the current build and use it to store the configured targets.
                     // We store them because we override them during the build and we'll need
                     // their original values at the tear down stage so that they can be restored.
-                    ConcurrentJobsHelper.ConcurrentBuild concurrentBuild = ConcurrentJobsHelper.concurrentBuildHandler.get(buildName);
+                    ConcurrentJobsHelper.ConcurrentBuild concurrentBuild = ConcurrentJobsHelper.getConcurrentBuild(build);
                     // Remove the Artifactory Plugin additional arguments, in case they are included in the targets string:
                     String targets = antBuild.getTargets() != null ? antBuild.getTargets().replace(getAntArgs(), "") : "";
                     concurrentBuild.putParam("targets", targets);
@@ -392,7 +392,7 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
             }
 
             @Override
-            public boolean tearDown(AbstractBuild build, BuildListener listener)
+            public boolean tearDown(final AbstractBuild build, BuildListener listener)
                     throws IOException, InterruptedException {
                 Result result = build.getResult();
 
@@ -401,12 +401,12 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
                     // inside its tearDown() method is invoked by only one job in this build
                     // (matrix project builds include more that one job) and that this
                     // job is the last one running.
-                    new ConcurrentJobsHelper.ConcurrentBuildTearDownSync(buildName, result) {
+                    new ConcurrentJobsHelper.ConcurrentBuildTearDownSync(build, result) {
                         @Override
                         public void tearDown() {
                             // Restore the original targets of this build (we overrided their
                             // values in the setUp stage):
-                            ConcurrentJobsHelper.ConcurrentBuild concurrentBuild = ConcurrentJobsHelper.concurrentBuildHandler.get(buildName);
+                            ConcurrentJobsHelper.ConcurrentBuild concurrentBuild = ConcurrentJobsHelper.getConcurrentBuild(build);
                             String targets = concurrentBuild.getParam("targets");
                             // Remove the Artifactory Plugin additional arguments, in case they are included in the targets string:
                             targets = targets.replace(getAntArgs(), "");
@@ -426,7 +426,7 @@ public class ArtifactoryIvyFreeStyleConfigurator extends BuildWrapper implements
 
                 // Aborted action by the user:
                 if (Result.ABORTED.equals(result)) {
-                    ConcurrentJobsHelper.concurrentBuildHandler.remove(buildName);
+                    ConcurrentJobsHelper.removeConcurrentBuildJob(build);
                 }
                 return true;
             }

--- a/src/main/java/org/jfrog/hudson/util/ConcurrentJobsHelper.java
+++ b/src/main/java/org/jfrog/hudson/util/ConcurrentJobsHelper.java
@@ -1,5 +1,6 @@
 package org.jfrog.hudson.util;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -10,7 +11,37 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Lior Hasson
  */
 public class ConcurrentJobsHelper {
-    public static ConcurrentHashMap<String, ConcurrentBuild> concurrentBuildHandler = new ConcurrentHashMap<String, ConcurrentBuild>();
+    private static ConcurrentHashMap<String, ConcurrentBuild> concurrentBuildHandler = new ConcurrentHashMap<String, ConcurrentBuild>();
+
+    /**
+     * Get an 'identifier' for the build which is composed of {@link BuildUniqueIdentifierHelper#getBuildName(AbstractBuild)}
+     * -{@link AbstractBuild#getNumber()}. This supports even concurrent builds of the same buildjob on a slave.
+     *
+     * @param build The build
+     * @return The identifier for the given build.
+     */
+    private static String getConcurrentBuildJobId(AbstractBuild build) {
+        return BuildUniqueIdentifierHelper.getBuildName(build) + "." + build.getNumber();
+    }
+
+    /**
+     * Get the information for the given build.
+     *
+     * @param build The build
+     * @return The information about the build
+     */
+    public static ConcurrentBuild getConcurrentBuild(AbstractBuild build) {
+        return concurrentBuildHandler.get(getConcurrentBuildJobId(build));
+    }
+
+    /**
+     * Removes the information for the given build.
+     *
+     * @param build The build
+     */
+    public static void removeConcurrentBuildJob(AbstractBuild build) {
+        concurrentBuildHandler.remove(getConcurrentBuildJobId(build));
+    }
 
     /**
      * The class is used to synchronize the setup stage of jobs which are part of the same multi-configuration project (matrix projects).
@@ -22,16 +53,16 @@ public class ConcurrentJobsHelper {
      * and in addtion, all jobs will wait till the initialization is finished.
      */
     public static abstract class ConcurrentBuildSetupSync {
-        public ConcurrentBuildSetupSync(String buildName, int totalBuilds) {
+        public ConcurrentBuildSetupSync(AbstractBuild build, int totalBuilds) {
             // Add the build to the concurrent map
             ConcurrentBuild newBuild = new ConcurrentBuild(new AtomicInteger(totalBuilds));
-            ConcurrentBuild build = concurrentBuildHandler.putIfAbsent(buildName, newBuild);
-            build = build == null ? newBuild : build;
+            ConcurrentBuild existingBuild = concurrentBuildHandler.putIfAbsent(getConcurrentBuildJobId(build), newBuild);
+            existingBuild = existingBuild == null ? newBuild : existingBuild;
 
             if (totalBuilds == 1) {
                 setUp();
             } else {
-                setupMultiBuild(build);
+                setupMultiBuild(existingBuild);
             }
         }
 
@@ -68,11 +99,12 @@ public class ConcurrentJobsHelper {
      * The tearDown() method will be invoked by only the last job running.
      */
     public static abstract class ConcurrentBuildTearDownSync {
-        public ConcurrentBuildTearDownSync(String buildName, Result buildResult) {
-            ConcurrentBuild build = concurrentBuildHandler.get(buildName);
-            if (build.getThreadsCounter().decrementAndGet() == 0 || Result.ABORTED.equals(buildResult)) {
+
+        public ConcurrentBuildTearDownSync(AbstractBuild build, Result buildResult) {
+            ConcurrentBuild concurrentBuild = concurrentBuildHandler.get(getConcurrentBuildJobId(build));
+            if (concurrentBuild.getThreadsCounter().decrementAndGet() == 0 || Result.ABORTED.equals(buildResult)) {
                 tearDown();
-                concurrentBuildHandler.remove(buildName);
+                removeConcurrentBuildJob(build);
             }
         }
 


### PR DESCRIPTION
Currently i'm occasionally getting the following NPE when executing concurrent builds of the same job with the artifactory plugin enabled. That's because the current implementation uses only the name of the build as the key for handling concurrent builds, which is enough for multiconfiguration-jobs but not in case of executing the same job concurrently.

`java.lang.NullPointerException
	at org.jfrog.hudson.util.ConcurrentJobsHelper$ConcurrentBuildTearDownSync.<init>(ConcurrentJobsHelper.java:73)
	at org.jfrog.hudson.gradle.ArtifactoryGradleConfigurator$2$1.<init>(ArtifactoryGradleConfigurator.java:557)
	at org.jfrog.hudson.gradle.ArtifactoryGradleConfigurator$2.tearDown(ArtifactoryGradleConfigurator.java:557)
	at hudson.model.Build$BuildExecution.doRun(Build.java:173)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:534)
	at hudson.model.Run.execute(Run.java:1738)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:410)`