### PR TITLE
Enabling Overriding of Build Name

### DIFF
--- a/src/main/java/org/jfrog/hudson/AbstractBuildInfoDeployer.java
+++ b/src/main/java/org/jfrog/hudson/AbstractBuildInfoDeployer.java
@@ -47,7 +47,7 @@ public class AbstractBuildInfoDeployer {
 
     protected Build createBuildInfo(String buildAgentName, String buildAgentVersion, BuildType buildType) {
         BuildInfoBuilder builder = new BuildInfoBuilder(
-                BuildUniqueIdentifierHelper.getBuildName(build))
+                BuildUniqueIdentifierHelper.getBuildName(build,listener))
                 .number(BuildUniqueIdentifierHelper.getBuildNumber(build)).type(buildType)
                 .artifactoryPluginVersion(ActionableHelper.getArtifactoryPluginVersion())
                 .buildAgent(new BuildAgent(buildAgentName, buildAgentVersion))

--- a/src/main/java/org/jfrog/hudson/BintrayPublish/BintrayPublishAction.java
+++ b/src/main/java/org/jfrog/hudson/BintrayPublish/BintrayPublishAction.java
@@ -256,7 +256,7 @@ public class BintrayPublishAction<C extends BuildInfoAwareConfigurator & Deploye
                 try {
                     logger.println("Publishing to Bintray...");
                     if (isValidArtifactoryVersion(client)) {
-                        String buildName = BuildUniqueIdentifierHelper.getBuildName(build);
+                        String buildName = BuildUniqueIdentifierHelper.getBuildName(build, listener);
                         String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
                         BintrayResponse response = client.pushToBintray(buildName, buildNumber, signMethod,
                                 passphrase, uploadInfoOverride);

--- a/src/main/java/org/jfrog/hudson/BuildInfoResultAction.java
+++ b/src/main/java/org/jfrog/hudson/BuildInfoResultAction.java
@@ -63,7 +63,7 @@ public class BuildInfoResultAction implements BuildBadgeAction {
     }
 
     private String generateUrl(String artifactoryRootUrl, AbstractBuild build) {
-        return artifactoryRootUrl + "/webapp/builds/" + Util.rawEncode(BuildUniqueIdentifierHelper.getBuildName(build)) + "/"
+        return artifactoryRootUrl + "/webapp/builds/" + Util.rawEncode(BuildUniqueIdentifierHelper.getBuildName(build, listener)) + "/"
                 + Util.rawEncode(BuildUniqueIdentifierHelper.getBuildNumber(build));
     }
 }

--- a/src/main/java/org/jfrog/hudson/generic/GenericArtifactsDeployer.java
+++ b/src/main/java/org/jfrog/hudson/generic/GenericArtifactsDeployer.java
@@ -85,7 +85,7 @@ public class GenericArtifactsDeployer {
     private ArrayListMultimap<String, String> getbuildPropertiesMap() {
         ArrayListMultimap<String, String> properties = ArrayListMultimap.create();
 
-        properties.put("build.name", BuildUniqueIdentifierHelper.getBuildName(build));
+        properties.put("build.name", BuildUniqueIdentifierHelper.getBuildName(build, listener));
         properties.put("build.number", BuildUniqueIdentifierHelper.getBuildNumber(build));
         properties.put("build.timestamp", build.getTimestamp().getTime().getTime() + "");
         Cause.UpstreamCause parent = ActionableHelper.getUpstreamCause(build);

--- a/src/main/java/org/jfrog/hudson/release/UnifiedPromoteBuildAction.java
+++ b/src/main/java/org/jfrog/hudson/release/UnifiedPromoteBuildAction.java
@@ -309,7 +309,7 @@ public class UnifiedPromoteBuildAction<C extends BuildInfoAwareConfigurator & De
 
         private void handlePluginPromotion(TaskListener listener, ArtifactoryBuildInfoClient client)
                 throws IOException {
-            String buildName = BuildUniqueIdentifierHelper.getBuildName(build);
+            String buildName = BuildUniqueIdentifierHelper.getBuildName(build, listener);
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
             HttpResponse pluginPromotionResponse = client.executePromotionUserPlugin(
                     promotionPlugin.getPluginName(), buildName, buildNumber, promotionPlugin.getParamMap());
@@ -332,7 +332,7 @@ public class UnifiedPromoteBuildAction<C extends BuildInfoAwareConfigurator & De
                     .dryRun(true);
             listener.getLogger()
                     .println("Performing dry run promotion (no changes are made during dry run) ...");
-            String buildName = BuildUniqueIdentifierHelper.getBuildName(build);
+            String buildName = BuildUniqueIdentifierHelper.getBuildName(build, listener);
             String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);
             HttpResponse dryResponse = client.stageBuild(buildName, buildNumber, promotionBuilder.build());
             if (checkSuccess(dryResponse, true, true, listener)) {

--- a/src/main/java/org/jfrog/hudson/util/BuildUniqueIdentifierHelper.java
+++ b/src/main/java/org/jfrog/hudson/util/BuildUniqueIdentifierHelper.java
@@ -8,6 +8,7 @@ import org.jfrog.hudson.ArtifactoryRedeployPublisher;
 import org.jfrog.hudson.action.ActionableHelper;
 import org.jfrog.hudson.gradle.ArtifactoryGradleConfigurator;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 
@@ -114,7 +115,13 @@ public class BuildUniqueIdentifierHelper {
         return null;
     }
 
-    public static String getBuildName(AbstractBuild build) {
+    public static String getBuildName(AbstractBuild build, BuildListener listener) {
+        String productName = build.getEnvironment(listener).get("PRODUCT_NAME");
+        if(productName != null && productName.length() > 0)
+        {
+            debuggingLogger.log(Level.INFO, "Detected PRODUCT_NAME", productName);
+            return productName;
+        }
         String lastItemInBuildName = build.getProject().getName();
         String buildName = build.getProject().getFullName();
         if (!buildName.equals(lastItemInBuildName)) {

--- a/src/main/java/org/jfrog/hudson/util/BuildUniqueIdentifierHelper.java
+++ b/src/main/java/org/jfrog/hudson/util/BuildUniqueIdentifierHelper.java
@@ -2,12 +2,18 @@ package org.jfrog.hudson.util;
 
 import hudson.matrix.Combination;
 import hudson.matrix.MatrixRun;
-import hudson.model.*;
-import org.apache.commons.lang.StringUtils;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.BuildableItemWithBuildWrappers;
+import hudson.model.Cause;
+import hudson.model.Hudson;
+import hudson.model.Item;
 import org.jfrog.hudson.ArtifactoryRedeployPublisher;
 import org.jfrog.hudson.action.ActionableHelper;
 import org.jfrog.hudson.gradle.ArtifactoryGradleConfigurator;
 
+import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -116,7 +122,15 @@ public class BuildUniqueIdentifierHelper {
     }
 
     public static String getBuildName(AbstractBuild build, BuildListener listener) {
-        String productName = build.getEnvironment(listener).get("PRODUCT_NAME");
+        String productName = null;
+        try
+        {
+            productName = build.getEnvironment(listener).get("PRODUCT_NAME");
+        }
+        catch (Exception e)
+        {
+            debuggingLogger.log(Level.WARNING, "Unable to fetch the env variable PRODUCT_NAME", e);
+        }
         if(productName != null && productName.length() > 0)
         {
             debuggingLogger.log(Level.INFO, "Detected PRODUCT_NAME", productName);

--- a/src/main/java/org/jfrog/hudson/util/ConcurrentJobsHelper.java
+++ b/src/main/java/org/jfrog/hudson/util/ConcurrentJobsHelper.java
@@ -15,14 +15,14 @@ public class ConcurrentJobsHelper {
     private static ConcurrentHashMap<String, ConcurrentBuild> concurrentBuildHandler = new ConcurrentHashMap<String, ConcurrentBuild>();
 
     /**
-     * Get an 'identifier' for the build which is composed of {@link BuildUniqueIdentifierHelper#getBuildName(AbstractBuild)}
+     * Get an 'identifier' for the build which is composed of {@link BuildUniqueIdentifierHelper#getBuildName(AbstractBuild, BuildListener)}
      * -{@link AbstractBuild#getNumber()}. This supports even concurrent builds of the same buildjob on a slave.
      *
      * @param build The build
      * @return The identifier for the given build.
      */
     private static String getConcurrentBuildJobId(AbstractBuild build) {
-        return BuildUniqueIdentifierHelper.getBuildName(build) + "." + build.getNumber();
+        return BuildUniqueIdentifierHelper.getBuildName(build, listener) + "." + build.getNumber();
     }
 
     /**

--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -216,7 +216,7 @@ public class ExtractorUtils {
                                          PublisherContext context, ArtifactoryClientConfiguration configuration) {
         configuration.setActivateRecorder(Boolean.TRUE);
 
-        String buildName = BuildUniqueIdentifierHelper.getBuildName(build);
+        String buildName = BuildUniqueIdentifierHelper.getBuildName(build, listener);
         configuration.info.setBuildName(buildName);
         configuration.publisher.addMatrixParam("build.name", buildName);
         String buildNumber = BuildUniqueIdentifierHelper.getBuildNumber(build);


### PR DESCRIPTION
The build name is currently the name of the Jenkins job while in the context of a Jenkins pipeline job, it does not make sense to fix it the jenkins job that is actually doing the upload. In many cases, the pipeline job consists of a sequence of jenkins jobs and the build-info is common for all these stages. 

Given this context, it is needed that we can customize the name used for build for the build info. This PR handles that.