### PR TITLE
Using AbstractSynchronousNonBlockingStepExecution for blocking operations

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/steps/DownloadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/DownloadStep.java
@@ -41,7 +41,7 @@ public class DownloadStep extends AbstractStepImpl {
         return server;
     }
 
-    public static class Execution extends AbstractSynchronousStepExecution<BuildInfo> {
+    public static class Execution extends AbstractSynchronousNonBlockingStepExecution<BuildInfo> {
         private static final long serialVersionUID = 1L;
         @StepContextParameter
         private transient FilePath ws;

--- a/src/main/java/org/jfrog/hudson/pipeline/steps/PromoteBuildStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/PromoteBuildStep.java
@@ -35,7 +35,7 @@ public class PromoteBuildStep extends AbstractStepImpl {
         return promotionConfig;
     }
 
-    public static class Execution extends AbstractSynchronousStepExecution<Boolean> {
+    public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Boolean> {
         private static final long serialVersionUID = 1L;
 
         @StepContextParameter

--- a/src/main/java/org/jfrog/hudson/pipeline/steps/PublishBuildInfoStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/PublishBuildInfoStep.java
@@ -35,7 +35,7 @@ public class PublishBuildInfoStep extends AbstractStepImpl {
         return server;
     }
 
-    public static class Execution extends AbstractSynchronousStepExecution<Boolean> {
+    public static class Execution extends AbstractSynchronousNonBlockingStepExecution<Boolean> {
         private static final long serialVersionUID = 1L;
         @StepContextParameter
         private transient FilePath ws;

--- a/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
@@ -42,7 +42,7 @@ public class UploadStep extends AbstractStepImpl {
     }
 
 
-    public static class Execution extends AbstractSynchronousStepExecution<BuildInfo> {
+    public static class Execution extends AbstractSynchronousNonBlockingStepExecution<BuildInfo> {
         private static final long serialVersionUID = 1L;
         @StepContextParameter
         private transient FilePath ws;


### PR DESCRIPTION
The main purpose is to ensure that any steps which involve I/O (contacting the Artifactory server) are cleanly interruptible, and will display `TaskListener` messages progressively if they are taking a long time.

As a side effect, this _might_ also solve a reported bug similar to [JENKINS-37538](https://issues.jenkins-ci.org/browse/JENKINS-37538) which I have so far not managed to reproduce:

```
javax.xml.parsers.FactoryConfigurationError: Provider for class javax.xml.parsers.DocumentBuilderFactory cannot be created
	at javax.xml.parsers.FactoryFinder.findServiceProvider(FactoryFinder.java:311)
	at javax.xml.parsers.FactoryFinder.find(FactoryFinder.java:267)
	at javax.xml.parsers.DocumentBuilderFactory.newInstance(DocumentBuilderFactory.java:120)
	at org.codehaus.jackson.map.ext.CoreXMLDeserializers$DOMDeserializer.<clinit>(CoreXMLDeserializers.java:118)
	at org.codehaus.jackson.map.ext.CoreXMLDeserializers.provide(CoreXMLDeserializers.java:58)
	at org.codehaus.jackson.map.deser.StdDeserializers.<init>(StdDeserializers.java:84)
	at org.codehaus.jackson.map.deser.StdDeserializers.constructAll(StdDeserializers.java:107)
	at org.codehaus.jackson.map.deser.BasicDeserializerFactory.<clinit>(BasicDeserializerFactory.java:46)
	at org.codehaus.jackson.map.deser.StdDeserializerProvider.<init>(StdDeserializerProvider.java:83)
	at org.codehaus.jackson.map.ObjectMapper.<init>(ObjectMapper.java:395)
	at org.codehaus.jackson.map.ObjectMapper.<init>(ObjectMapper.java:364)
	at org.codehaus.jackson.map.ObjectMapper.<init>(ObjectMapper.java:335)
	at org.jfrog.hudson.pipeline.executors.GenericDownloadExecutor.execution(GenericDownloadExecutor.java:50)
	at org.jfrog.hudson.pipeline.steps.DownloadStep$Execution.run(DownloadStep.java:60)
	at org.jfrog.hudson.pipeline.steps.DownloadStep$Execution.run(DownloadStep.java:44)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution.start(AbstractSynchronousStepExecution.java:40)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:178)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:124)
	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:117)
	at org.jfrog.hudson.pipeline.types.ArtifactoryServer.download(ArtifactoryServer.java:74)
	at org.jfrog.hudson.pipeline.types.ArtifactoryServer.download(ArtifactoryServer.java:48)
	at …
Caused by: java.lang.RuntimeException: Provider for class javax.xml.parsers.DocumentBuilderFactory cannot be created
	at javax.xml.parsers.FactoryFinder.findServiceProvider(FactoryFinder.java:308)
	at javax.xml.parsers.FactoryFinder.find(FactoryFinder.java:267)
	at javax.xml.parsers.DocumentBuilderFactory.newInstance(DocumentBuilderFactory.java:120)
	at org.codehaus.jackson.map.ext.CoreXMLDeserializers$DOMDeserializer.<clinit>(CoreXMLDeserializers.java:118)
	at org.codehaus.jackson.map.ext.CoreXMLDeserializers.provide(CoreXMLDeserializers.java:58)
	at org.codehaus.jackson.map.deser.StdDeserializers.<init>(StdDeserializers.java:84)
	at org.codehaus.jackson.map.deser.StdDeserializers.constructAll(StdDeserializers.java:107)
	at org.codehaus.jackson.map.deser.BasicDeserializerFactory.<clinit>(BasicDeserializerFactory.java:46)
	at org.codehaus.jackson.map.deser.StdDeserializerProvider.<init>(StdDeserializerProvider.java:83)
	at org.codehaus.jackson.map.ObjectMapper.<init>(ObjectMapper.java:395)
	at org.codehaus.jackson.map.ObjectMapper.<init>(ObjectMapper.java:364)
	at org.codehaus.jackson.map.ObjectMapper.<init>(ObjectMapper.java:335)
	at org.jfrog.hudson.pipeline.executors.GenericDownloadExecutor.execution(GenericDownloadExecutor.java:50)
	at org.jfrog.hudson.pipeline.steps.DownloadStep$Execution.run(DownloadStep.java:60)
	at org.jfrog.hudson.pipeline.steps.DownloadStep$Execution.run(DownloadStep.java:44)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution.start(AbstractSynchronousStepExecution.java:40)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeStep(DSL.java:178)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:124)
	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:117)
	at org.jfrog.hudson.pipeline.types.ArtifactoryServer.download(ArtifactoryServer.java:74)
	at org.jfrog.hudson.pipeline.types.ArtifactoryServer.download(ArtifactoryServer.java:48)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoCachedMethodSiteNoUnwrap.invoke(PojoMetaMethodSite.java:210)
	at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:53)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:151)
	at org.kohsuke.groovy.sandbox.GroovyInterceptor.onMethodCall(GroovyInterceptor.java:21)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onMethodCall(SandboxInterceptor.java:115)
	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:149)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:146)
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.methodCall(SandboxInvoker.java:16)
	... 33 more
Caused by: java.util.ServiceConfigurationError: javax.xml.parsers.DocumentBuilderFactory: Provider org.apache.xerces.jaxp.DocumentBuilderFactoryImpl not a subtype
	at java.util.ServiceLoader.fail(ServiceLoader.java:239)
	at java.util.ServiceLoader.access$300(ServiceLoader.java:185)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:376)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
	at javax.xml.parsers.FactoryFinder$1.run(FactoryFinder.java:294)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.xml.parsers.FactoryFinder.findServiceProvider(FactoryFinder.java:289)
	... 67 more
```

@reviewbybees