### PR TITLE
Add optional module id variable

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/types/buildInfo/BuildInfo.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/types/buildInfo/BuildInfo.java
@@ -178,7 +178,9 @@ public class BuildInfo implements Serializable {
         List<Module> dockerModules = dockerBuildInfoHelper.generateBuildInfoModules(build, listener, config, launcher);
 
         addDockerBuildInfoModules(dockerModules);
-        addDefaultModuleToModules(ExtractorUtils.sanitizeBuildName(build.getParent().getDisplayName()));
+
+        String customModuleId = getEnvVars().get("ARTIFACTORY_MODULE_ID");
+        addDefaultModuleToModules(customModuleId != null ? ExtractorUtils.sanitizeBuildName(customModuleId) : ExtractorUtils.sanitizeBuildName(build.getParent().getDisplayName()));
         return new BuildInfoDeployer(config, client, build, listener, new BuildInfoAccessor(this));
     }
 


### PR DESCRIPTION
Enables users to override the default module id name by setting ARTIFACTORY_MODULE_ID. This is necessary for users who cannot rename their Jenkins job name due to the [Github org plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Organization+Folder+Plugin) which forces the name to reflect the branch name. E.g. in our case the module id would always be master.