### PR TITLE
2nd fix link to build result: replace %2F with ' :: '

### DIFF
--- a/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
+++ b/src/main/java/org/jfrog/hudson/util/ExtractorUtils.java
@@ -408,7 +408,8 @@ public class ExtractorUtils {
      * Replaces occurrences of '/' with ' :: ' if exist
      */
     public static String sanitizeBuildName(String buildName) {
-        return StringUtils.replace(buildName, "/", " :: ");
+        String sanitisedString = StringUtils.replace(buildName, "/", " :: ");
+        return StringUtils.replace(sanitisedString, "%2F", " :: ");
     }
 
     /**


### PR DESCRIPTION
Fixing the issue where, if you have a Jenkins Multibranch Pipeline job configured, and you use labeled branches (my/branch/name), after uploading to Artifactory you have a link similar to "my :: branch%2Fname" under the Builds menu, which cannot be navigated to. 

This is replacing "%2F" with " :: " in addition to replacing "/" with " :: ". 