### PR TITLE
added credentials resolving for generic upload step

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/UploadStep.java
@@ -63,7 +63,16 @@ public class UploadStep extends AbstractStepImpl {
 
         @Override
         protected BuildInfo run() throws Exception {
-            BuildInfo buildInfo = new GenericUploadExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), listener, build, ws, step.getBuildInfo(), getContext()).execution(Util.replaceMacro(step.getSpec(), env));
+            GenericUploadExecutor executor = new GenericUploadExecutor(
+                Utils.prepareArtifactoryServer(null, step.getServer()), 
+                listener, 
+                build, 
+                ws, 
+                step.getBuildInfo(), 
+                getContext(), 
+                step.getServer().createCredentialsConfig()
+            );
+            BuildInfo buildInfo = executor.execution(Util.replaceMacro(step.getSpec(), env));
             new BuildInfoAccessor(buildInfo).captureVariables(env, build, listener);
             return buildInfo;
         }


### PR DESCRIPTION
We want to use Jenkins pipeline scripts like this:
```
	def server = Artifactory.server('...')
	def uploadSpec = """{
		"files": [{
			"pattern": "...",
			"target": "..."
		}]
	}"""
	server.credentialsId = '...'
	def buildInfo = server.upload(uploadSpec)
	server.publishBuildInfo(buildInfo)
```
There was no resolving of username and password for given credentialsId.