### PR TITLE
Make Docker build-info proxy listen on all interfaces

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/docker/proxy/BuildInfoProxyManager.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/docker/proxy/BuildInfoProxyManager.java
@@ -35,6 +35,7 @@ public class BuildInfoProxyManager implements Serializable {
                 .build();
 
         server = DefaultHttpProxyServer.bootstrap()
+                .withListenOnAllAddresses(true)
                 .withPort(proxyPort)
                 .withAllowLocalOnly(false)
                 .withFiltersSource(new BuildInfoHttpFiltersSource())


### PR DESCRIPTION
In case of using dockerized Jenkins instance, build-info proxy is started on the loopback interface only, making impossible for an external Jenkins slave to use it. The change is to make the build-info proxy listen on all network interfaces.