### PR TITLE
Add a space between maven option strings

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/steps/ArtifactoryMavenBuild.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/ArtifactoryMavenBuild.java
@@ -103,7 +103,12 @@ public class ArtifactoryMavenBuild extends AbstractStepImpl {
             MavenGradleEnvExtractor envExtractor = new MavenGradleEnvExtractor(build,
                     buildInfo, deployer, step.getMavenBuild().getResolver(), listener, launcher);
             envExtractor.buildEnvVars(ws, env);
-            String mavenOpts = step.getOpts() + (env.get("MAVEN_OPTS") != null ? env.get("MAVEN_OPTS") : "");
+            String stepOpts = step.getOpts();
+            String mavenOpts = stepOpts + (
+                env.get("MAVEN_OPTS") != null ? (
+                    stepOpts.length() > 0 ? " " : ""
+                ) + env.get("MAVEN_OPTS") : ""
+            );
             mavenOpts = mavenOpts.replaceAll("[\t\r\n]+", " ");
             Maven3Builder maven3Builder = new Maven3Builder(step.getTool(), step.getPom(), step.getGoal(), mavenOpts);
             convertJdkPath();


### PR DESCRIPTION
Currently if options are supplied in both the step and the MAVEN_OPTS environment variable, the end of the step's options will run straight into the MAVEN_OPTS contents, causing the options to be broken.

If both are included then a space should be added between them to allow them both to work without special knowledge of how they are combined here.