### PR TITLE
[Promotion] targetRepo should not be mandatory.

### DIFF
--- a/docs/pipeline.wiki.markup
+++ b/docs/pipeline.wiki.markup
@@ -168,9 +168,9 @@ To promote a build between repositories in Artifactory, define the promotion par
         // Mandatory parameters
         'buildName'          : buildInfo.name,
         'buildNumber'        : buildInfo.number,
-        'targetRepo'         : 'libs-release-local',
 
         // Optional parameters
+        'targetRepo'         : 'libs-release-local',
         'comment'            : 'this is the promotion comment',
         'sourceRepo'         : 'libs-snapshot-local',
         'status'             : 'Released',

--- a/src/main/java/org/jfrog/hudson/pipeline/steps/PromoteBuildStep.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/steps/PromoteBuildStep.java
@@ -61,11 +61,6 @@ public class PromoteBuildStep extends AbstractStepImpl {
                 return false;
             }
 
-            if (StringUtils.isEmpty(promotionConfig.getTargetRepo())) {
-                getContext().onFailure(new MissingArgumentException("Promotion target repository is mandatory"));
-                return false;
-            }
-
             new PromotionExecutor(Utils.prepareArtifactoryServer(null, step.getServer()), build, listener, getContext(), promotionConfig).execution();
             return true;
         }


### PR DESCRIPTION
Hi,

I don't think the "targetRepo" field at promotion time should be mandatory. In the doc of the REST API here https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-BuildPromotion it is marked as optional.

I have a scenario where my build produces artefacts in several repo. The upload and publishBuildInfo steps are working correctly when using several repo for the same build. But when promoting the build, all artefacts are going to the same targetRepo, while I expect them to go in their dedicated release repo instead (which are all different).

I am unable to test that, and know quite little about Artifactory, so I may be wrong. But it's strange to require this argument in the Jenkins plugin while the REST API doesn't.

Cheers,
Romain 