### PR TITLE
Send release and queue metadata back as JSON in the response body

### DIFF
--- a/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
+++ b/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
@@ -27,6 +27,7 @@ import hudson.matrix.MatrixProject;
 import hudson.model.*;
 import hudson.tasks.BuildWrapper;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jfrog.hudson.ArtifactoryPlugin;
 import org.jfrog.hudson.ArtifactoryServer;
@@ -284,14 +285,21 @@ public abstract class ReleaseAction<P extends AbstractProject & BuildableItem,
             overrideStagingPluginParams(req);
             // Schedule the release build:
             Queue.WaitingItem item = Jenkins.getInstance().getQueue().schedule(
-                    project, 0,
-                    new Action[]{this, new CauseAction(new Cause.UserIdCause())}
+                project, 0,
+                new Action[]{this, new CauseAction(new Cause.UserIdCause())}
             );
             if (item == null) {
                 log.log(Level.SEVERE, "Failed to schedule a release build following a Release API invocation");
                 resp.setStatus(StaplerResponse.SC_INTERNAL_SERVER_ERROR);
             } else {
                 String url = req.getContextPath() + '/' + item.getUrl();
+                JSONObject json = new JSONObject();
+                json.element("queueItem", item.id);
+                json.element("releaseVersion", getReleaseVersion());
+                json.element("nextVersion", getNextVersion());
+                json.element("releaseBranch", getReleaseBranch());
+                // Must use getOutputStream as sendRedirect uses getOutputStream (and closes it)
+                resp.getOutputStream().print(json.toString());
                 resp.sendRedirect(201, url);
             }
         } catch (Exception e) {


### PR DESCRIPTION
This is to allow API users to get metadata back such as the release version and next development version when these parameters are not supplied in the request (i.e. when allowing the API to use the defaults). This also returns the queue item id as its own field so it can be used explicitly rather than parsed from the Location header.

The Location header and HTTP 201 response code is left as-is to conform to the vanilla build API.