### PR TITLE
Fix possible NullPointerException

### DIFF
--- a/src/main/java/org/jfrog/hudson/pipeline/docker/utils/DockerUtils.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/docker/utils/DockerUtils.java
@@ -33,7 +33,9 @@ public class DockerUtils implements Serializable {
         } catch (Exception e) {
             return false;
         } finally {
-            dockerClient.close();
+            if (dockerClient != null) {
+                dockerClient.close();
+            }
         }
     }
 
@@ -50,7 +52,9 @@ public class DockerUtils implements Serializable {
             dockerClient = getDockerClient(host);
             return dockerClient.inspectImageCmd(imageTag).exec().getId();
         } finally {
-            dockerClient.close();
+            if (dockerClient != null) {
+                dockerClient.close();
+            }
         }
     }
 
@@ -72,7 +76,9 @@ public class DockerUtils implements Serializable {
             dockerClient = getDockerClient(host);
             dockerClient.pushImageCmd(imageTag).withAuthConfig(authConfig).exec(new PushImageResultCallback()).awaitSuccess();
         } finally {
-            dockerClient.close();
+            if (dockerClient != null) {
+                dockerClient.close();
+            }
         }
     }
 
@@ -94,7 +100,9 @@ public class DockerUtils implements Serializable {
             dockerClient = getDockerClient(host);
             dockerClient.pullImageCmd(imageTag).withAuthConfig(authConfig).exec(new PullImageResultCallback()).awaitSuccess();
         } finally {
-            dockerClient.close();
+            if (dockerClient != null) {
+                dockerClient.close();
+            }
         }
     }
 
@@ -111,7 +119,9 @@ public class DockerUtils implements Serializable {
             dockerClient = getDockerClient(host);
             return dockerClient.inspectImageCmd(digest).exec().getParent();
         } finally {
-            dockerClient.close();
+            if (dockerClient != null) {
+                dockerClient.close();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes a NullPointerException when DockerClient is unexpectedly null.

Stackstrace from my Jenkins:

```
java.lang.NullPointerException
	at org.jfrog.hudson.pipeline.docker.utils.DockerUtils.isDockerHostExists(DockerUtils.java:36)
	at org.jfrog.hudson.pipeline.docker.utils.DockerAgentUtils.registerImage(DockerAgentUtils.java:70)
	at org.jfrog.hudson.pipeline.docker.utils.DockerAgentUtils.access$000(DockerAgentUtils.java:21)
	at org.jfrog.hudson.pipeline.docker.utils.DockerAgentUtils$1.call(DockerAgentUtils.java:62)
	at org.jfrog.hudson.pipeline.docker.utils.DockerAgentUtils$1.call(DockerAgentUtils.java:60)
	at hudson.remoting.UserRequest.perform(UserRequest.java:153)
	at hudson.remoting.UserRequest.perform(UserRequest.java:50)
	at hudson.remoting.Request$2.run(Request.java:336)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
	at java.util.concurrent.FutureTask.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at hudson.remoting.Engine$1$1.run(Engine.java:94)
	at java.lang.Thread.run(Unknown Source)
	at ......remote call to JNLP4-connect connection from -----------windows-slave-ip----------(Native Method)
	at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1545)
	at hudson.remoting.UserResponse.retrieve(UserRequest.java:253)
	at hudson.remoting.Channel.call(Channel.java:830)
	at org.jfrog.hudson.pipeline.docker.utils.DockerAgentUtils.registerImageOnAgents(DockerAgentUtils.java:60)
	at org.jfrog.hudson.pipeline.steps.DockerPushStep$Execution.run(DockerPushStep.java:97)
	at org.jfrog.hudson.pipeline.steps.DockerPushStep$Execution.run(DockerPushStep.java:62)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1$1.call(AbstractSynchronousNonBlockingStepExecution.java:47)
	at hudson.security.ACL.impersonate(ACL.java:260)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1.run(AbstractSynchronousNonBlockingStepExecution.java:44)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
```