### PR TITLE
Fix NullPointerException when using the release API for the first build

### DIFF
--- a/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
+++ b/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
@@ -447,8 +447,10 @@ public abstract class ReleaseAction<P extends AbstractProject & BuildableItem,
     }
 
     protected void doGlobalVersioning() {
-        releaseVersion = defaultGlobalModule.getReleaseVersion();
-        nextVersion = defaultGlobalModule.getNextDevelopmentVersion();
+        if (defaultGlobalModule != null) {
+            releaseVersion = defaultGlobalModule.getReleaseVersion();
+            nextVersion = defaultGlobalModule.getNextDevelopmentVersion();
+        }
     }
 
     protected W getWrapper() {


### PR DESCRIPTION
If a new job is created and you try to use the API to do a release a NullPointerException comes back.
```
INFO: Initiating Artifactory Release Staging using API
Sep 07, 2017 12:28:18 PM org.jfrog.hudson.release.ReleaseAction doApi
SEVERE: Artifactory Release Staging API invocation failed: null
java.lang.NullPointerException
        at org.jfrog.hudson.release.ReleaseAction.doGlobalVersioning(ReleaseAction.java:434)
        at org.jfrog.hudson.release.ReleaseAction.readStagingPluginValues(ReleaseAction.java:529)
        at org.jfrog.hudson.release.ReleaseAction.doApi(ReleaseAction.java:281)
        at org.jfrog.hudson.release.maven.MavenReleaseApiAction.doStaging(MavenReleaseApiAction.java:33)
        at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
        at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:343)...
```
Strangely, with the same inputs, the form in the Jenkins UI worked just fine.

Adding a null check around the usage of defaultGlobalModule fixed the issue for me.