### PR TITLE
feat: include virtual repositories in UnifiedPromoteBuildAction

### DIFF
--- a/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
+++ b/src/main/java/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.jfrog.hudson.util.SerializationUtils.createMapper;
 
@@ -246,6 +247,14 @@ public class UnifiedPromoteBuildAction extends TaskAction implements BuildBadgeA
         }
         List<String> repos = artifactoryServer.
                 getReleaseRepositoryKeysFirst((DeployerOverrider) configurator, build.getParent());
+
+        List<String> virtualRepos = artifactoryServer.getVirtualRepositoryKeys((ResolverOverrider) configurator, build.getParent())
+            .stream()
+            .map(virtual -> virtual.getValue())
+            .sorted()
+            .collect(Collectors.toList());
+
+        repos.addAll(virtualRepos);
         repos.add(0, "");  // option not to move
         return repos;
     }


### PR DESCRIPTION
 include virtual repositories in UnifiedPromoteBuildAction's getRepositoryKeys(); Implements #584

- [x] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
-----
