### PR TITLE
Use jersey3. Update baseline to JDK 17, jenkins 2.516.3 (version wher…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.57</version>
+        <version>5.28</version>
+        <relativePath />
     </parent>
 
     <artifactId>artifactory</artifactId>
@@ -33,8 +34,8 @@
 
     <properties>
         <!-- Minimal version required by Pipeline dependencies in 2.14.0 -->
-        <jenkins.version>2.263.1</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.516.3</jenkins.version>
+        <java.level>17</java.level>
         <!-- TODO: enforcer is full of upper bound dependency issues, including real ones -->
         <enforcer.skip>true</enforcer.skip>
         <findbugs.failOnError>true</findbugs.failOnError>
@@ -46,6 +47,11 @@
     </properties>
 
     <repositories>
+        <repository>
+            <id>maven</id>
+            <name>maven</name>
+            <url>https://repo.jenkins-ci.org/releases</url>
+        </repository>
         <repository>
             <id>central</id>
             <name>central</name>
@@ -108,7 +114,6 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>3.4</version>
             <exclusions>
                 <exclusion>
                     <artifactId>httpcore</artifactId>
@@ -128,43 +133,26 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.29</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.18.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.13-1.0</version>
-            <exclusions>
-                <!-- An updated version of httpcomponents is received from the buildinfo dependency -->
-                <exclusion>
-                    <artifactId>httpcore</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>httpclient</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>config-file-provider</artifactId>
-            <version>3.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.15.1</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
@@ -181,13 +169,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.22</version>
         </dependency>
         <dependency>
             <!-- The git plugin is set as optional due to HAP-771 -->
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>3.3.2</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
@@ -199,7 +185,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.32</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -210,7 +195,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.34.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -221,23 +205,21 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ivy</artifactId>
-            <version>1.28</version>
+            <version>582.v35fb_da_0312f7</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.18.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ant</artifactId>
-            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>gradle</artifactId>
-            <version>1.15</version>
+            <version>2.18.1203.v2c96b_1243c72</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -248,17 +230,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.3.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>nodejs</artifactId>
-            <version>1.2.7</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -269,6 +248,18 @@
                 <exclusion>
                     <groupId>com.thoughtworks.xstream</groupId>
                     <artifactId>xstream</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>httpcore</artifactId>
+                    <groupId>org.apache.httpcomponents</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>httpclient</artifactId>
+                    <groupId>org.apache.httpcomponents</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -411,49 +402,49 @@
             <groupId>org.jfrog.buildinfo</groupId>
             <artifactId>build-info-extractor-docker</artifactId>
             <version>${buildinfo.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jfrog.buildinfo</groupId>
             <artifactId>build-info-extractor-nuget</artifactId>
             <version>${buildinfo.version}</version>
+            <exclusions>
+                <exclusion>
+                     <groupId>com.fasterxml.jackson.dataformat</groupId>
+                     <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.14.0</version>
+        </dependency>
+        <dependency>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs</artifactId>
+          <version>4.9.7</version>
         </dependency>
         <dependency>
             <!-- commons-compress is in use in the Go extractor -->
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.26.2</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-compress-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>compile</scope>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ivy</groupId>
@@ -462,38 +453,19 @@
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
-            <artifactId>jersey2-api</artifactId>
-            <version>2.35-8</version>
+            <artifactId>jersey3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jira</artifactId>
-            <version>3.0.14</version>
+            <version>3.2.1</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
                     <artifactId>branch-api</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.atlassian.jira</groupId>
-                    <artifactId>jira-rest-java-client-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.atlassian.jira</groupId>
-                    <artifactId>jira-rest-java-client-core</artifactId>
-                </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.jira</groupId>
-            <artifactId>jira-rest-java-client-api</artifactId>
-            <version>5.2.5</version>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.jira</groupId>
-            <artifactId>jira-rest-java-client-core</artifactId>
-            <version>5.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -510,12 +482,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.22</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.61.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -526,7 +496,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>2.23.1</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
@@ -544,32 +513,28 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.21</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.13.2.20220328-281.v9ecc7a_5e834f</version>
         </dependency>
 
         <!--Tests-->
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
-            <version>2.44</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
-            <version>2.0</version>
+            <version>608.v67378e9d3db_1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -587,7 +552,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>5.14.0</version>
+            <version>5.15.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -595,12 +560,6 @@
                     <artifactId>netty-handler</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs</artifactId>
-            <version>4.5.3</version>
-            <scope>test</scope>
         </dependency>
         <!--/Tests-->
     </dependencies>
@@ -617,6 +576,13 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
                 <version>1.77</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.516.x</artifactId>
+                <version>5750.vec44cb_c78352</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -637,11 +603,9 @@
                     <goals>deploy</goals>
                 </configuration>
             </plugin>
-            <!--Unit tests-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <!--This will disable JenkinsRule timeout-->
@@ -653,11 +617,12 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <!--Unit tests-->
+            
             <!--Integration tests-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <!--This will disable JenkinsRule timeout-->
@@ -721,21 +686,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.5.3.0</version>
-                <configuration>
-                    <excludeFilterFile>spotbugs-security-exclude.xml</excludeFilterFile>
-                    <plugins>
-                        <plugin>
-                            <groupId>com.h3xstream.findsecbugs</groupId>
-                            <artifactId>findsecbugs-plugin</artifactId>
-                            <version>1.10.1</version>
-                        </plugin>
-                    </plugins>
-                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
+++ b/src/main/java/org/jfrog/hudson/pipeline/common/types/buildInfo/BuildInfo.java
@@ -18,6 +18,7 @@ import org.jfrog.build.client.DeployableArtifactDetail;
 import org.jfrog.build.extractor.builder.BuildInfoBuilder;
 import org.jfrog.build.extractor.builder.ModuleBuilder;
 import org.jfrog.build.extractor.ci.*;
+import org.jfrog.build.extractor.ci.Module;
 import org.jfrog.build.extractor.clientConfiguration.IncludeExcludePatterns;
 import org.jfrog.build.extractor.clientConfiguration.PatternMatcher;
 import org.jfrog.build.extractor.clientConfiguration.client.artifactory.ArtifactoryManager;

--- a/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
+++ b/src/main/java/org/jfrog/hudson/release/ReleaseAction.java
@@ -24,6 +24,7 @@ import hudson.Util;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
 import hudson.model.*;
+import static hudson.model.Descriptor.FormException;
 import hudson.tasks.BuildWrapper;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -653,7 +654,11 @@ public abstract class ReleaseAction<P extends AbstractProject & BuildableItem,
 
     public StandardCredentials getGitCredentials() {
         if (overrideCredentials) {
-            return new UsernamePasswordCredentialsImpl(null, null, "release staging Git credentials", username, password);
+            try {
+                return new UsernamePasswordCredentialsImpl(null, null, "release staging Git credentials", username, password);
+            } catch(FormException e) {
+                return null;
+            }
         }
         return null;
     }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the plugin list page.
 

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryBuilder/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form"
          xmlns:st="jelly:stapler"

--- a/src/main/resources/org/jfrog/hudson/ArtifactoryRedeployPublisher/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/ArtifactoryRedeployPublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:r="/lib/jfrog" xmlns:st="jelly:stapler">
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:dropdownList name="deployerDetails" title="${%Artifactory server}">

--- a/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!-- displays a form to choose the next release and development version and re-schedules a build -->
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <?jelly escape-by-default='true'?>

--- a/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/summary.jelly
+++ b/src/main/resources/org/jfrog/hudson/BuildInfoResultAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:t="/lib/hudson">
     <t:summary icon="${it.iconFileName}">

--- a/src/main/resources/org/jfrog/hudson/XrayScanResultAction/summary.jelly
+++ b/src/main/resources/org/jfrog/hudson/XrayScanResultAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:t="/lib/hudson">
     <t:summary icon="${it.iconFileName}">

--- a/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/generic/ArtifactoryGenericConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form"
          xmlns:r="/lib/jfrog" xmlns:st="jelly:stapler">
 

--- a/src/main/resources/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/gradle/ArtifactoryGradleConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:r="/lib/jfrog">

--- a/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:r="/lib/jfrog" xmlns:c="/lib/credentials">

--- a/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/ivy/ArtifactoryIvyFreeStyleConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form"
          xmlns:r="/lib/jfrog"

--- a/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3Configurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   ~ Copyright (C) 2010 JFrog Ltd.
   ~

--- a/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/maven3/ArtifactoryMaven3NativeConfigurator/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:r="/lib/jfrog" xmlns:st="jelly:stapler">
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:dropdownList name="resolverDetails" title="${%Artifactory server}">

--- a/src/main/resources/org/jfrog/hudson/maven3/Maven3Builder/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/maven3/Maven3Builder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   ~ Copyright (C) 2010 JFrog Ltd.
   ~

--- a/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedGradleArtifactsAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedGradleArtifactsAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <l:layout title="Gradle Artifacts">
         <st:include it="${it.build}" page="sidepanel.jelly"/>

--- a/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedGradleArtifactsAction/summary.jelly
+++ b/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedGradleArtifactsAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:t="/lib/hudson">
     <j:if test="${!empty it.deployedArtifacts}">

--- a/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <l:layout title="Maven Artifacts">
         <st:include it="${it.build}" page="sidepanel.jelly"/>

--- a/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction/summary.jelly
+++ b/src/main/resources/org/jfrog/hudson/pipeline/action/DeployedMavenArtifactsAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:t="/lib/hudson">
     <j:if test="${!empty it.deployedArtifacts}">

--- a/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/badge.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/badge.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <j:choose>
         <j:when test="${it.hasPromotionPermission()}">

--- a/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/form.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/form.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!-- displays a form to choose the repository to promote the build to -->
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <?jelly escape-by-default='true'?>

--- a/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/progress.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/PromoteBuildAction/progress.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <l:layout norefresh="true">

--- a/src/main/resources/org/jfrog/hudson/release/gradle/GradleReleaseAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/gradle/GradleReleaseAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!-- displays a form to choose the next release and development version and re-schedules a build -->
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"

--- a/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseAction/index.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!-- displays a form to choose the next release and development version and re-schedules a build -->
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"

--- a/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseWrapper/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/maven/MavenReleaseWrapper/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">

--- a/src/main/resources/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction/form.jelly
+++ b/src/main/resources/org/jfrog/hudson/release/promotion/UnifiedPromoteBuildAction/form.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!-- displays a form to choose the repository to promote the build to -->
 <!--suppress XmlUnusedNamespaceDeclaration -->
 <?jelly escape-by-default='true'?>

--- a/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryMultibranchTrigger/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryMultibranchTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:dropdownList name="details" title="${%Artifactory server}">
         <j:forEach var="s" items="${instance.jfrogInstances ?: descriptor.jfrogInstances}" varStatus="loop">

--- a/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryTrigger/config.jelly
+++ b/src/main/resources/org/jfrog/hudson/trigger/ArtifactoryTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:dropdownList name="details" title="${%Artifactory server}">
         <j:forEach var="s" items="${instance.jfrogInstances ?: descriptor.jfrogInstances}" varStatus="loop">


### PR DESCRIPTION
…e jersey3-api starts appearing)

Resolves #961

- [X] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----
