### PR TITLE
change docker image tag for release pipeline

### DIFF
--- a/release/pipelines.release.yml
+++ b/release/pipelines.release.yml
@@ -4,10 +4,9 @@ pipelines:
       runtime:
         type: image
         image:
-          auto:
-            language: java
-            versions:
-              - "8.0.0"
+          custom:
+            name: releases-docker.jfrog.io/jfrog/pipelines-u18java
+            tag: "8.0.0"
       environmentVariables:
         readOnly:
           NEXT_VERSION: 0.0.0


### PR DESCRIPTION
- [ ] This pull request is created in the [jfrog/jenkins-artifactory-plugin](https://github.com/jfrog/jenkins-artifactory-plugin) repository.
- [ ] All [tests](https://ci.appveyor.com/project/jfrog-ecosystem/jenkins-artifactory-plugin) passed. If this feature is not already covered by the tests, I added new tests.
-----
 Problem: In jfrog release pipelines the auto runtime for language: java started resolving to pipelines-u20java:8.0.0, which does not exist in releases-docker.jfrog.io. This caused the Release step to fail at container boot with a
 manifest unknown error.

  Solution: Switched the runtime from auto to custom, explicitly pinning releases-docker.jfrog.io/jfrog/pipelines-u18java:8.0.0  the same image used by the last successful run.